### PR TITLE
fix: [FSDK-2213] Add User-Agent in MediaShare app requests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,6 +46,6 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 
-    implementation "co.thingthing.fleksycore:fleksycore-release:4.13.2"
+    implementation "co.thingthing.fleksycore:fleksycore-release:4.15.2"
     api project(':mediashare')
 }

--- a/mediashare/build.gradle
+++ b/mediashare/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: "maven-publish"
 
 android {
     compileSdk 34

--- a/mediashare/src/main/java/co/thingthing/fleksyapps/mediashare/MediaShareApp.kt
+++ b/mediashare/src/main/java/co/thingthing/fleksyapps/mediashare/MediaShareApp.kt
@@ -17,6 +17,7 @@ import co.thingthing.fleksyapps.core.KeyboardAppViewMode
 import co.thingthing.fleksyapps.mediashare.models.MediaShareResponse
 import co.thingthing.fleksyapps.mediashare.models.toCategories
 import co.thingthing.fleksyapps.mediashare.network.MediaShareService
+import co.thingthing.fleksyapps.mediashare.network.getUserAgent
 import co.thingthing.fleksyapps.mediashare.network.toNetworkContentType
 import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -195,7 +196,8 @@ class MediaShareApp(
             contentType = contentType.toNetworkContentType(),
             mediaShareApiKey = apiKey,
             sdkLicenseId = sdkLicenseKey,
-            userId = androidId
+            userAgent = context.getUserAgent(),
+            userId = androidId,
         )
     }
 

--- a/mediashare/src/main/java/co/thingthing/fleksyapps/mediashare/network/Extensions.kt
+++ b/mediashare/src/main/java/co/thingthing/fleksyapps/mediashare/network/Extensions.kt
@@ -1,5 +1,7 @@
 package co.thingthing.fleksyapps.mediashare.network
 
+import android.content.Context
+import android.webkit.WebView
 import co.thingthing.fleksyapps.mediashare.MediaShareApp
 import co.thingthing.fleksyapps.mediashare.network.models.MediaShareRequestDTO
 
@@ -9,4 +11,6 @@ internal fun MediaShareApp.ContentType.toNetworkContentType() = when (this) {
     MediaShareApp.ContentType.GIFS -> MediaShareRequestDTO.ContentType.Gifs
     MediaShareApp.ContentType.STICKERS -> MediaShareRequestDTO.ContentType.Stickers
 }
+
+internal fun Context?.getUserAgent() = this?.let { WebView(it).settings.userAgentString }.orEmpty()
 

--- a/mediashare/src/main/java/co/thingthing/fleksyapps/mediashare/network/MediaShareService.kt
+++ b/mediashare/src/main/java/co/thingthing/fleksyapps/mediashare/network/MediaShareService.kt
@@ -9,7 +9,8 @@ internal class MediaShareService(
     private val contentType: MediaShareRequestDTO.ContentType,
     private val mediaShareApiKey: String,
     private val sdkLicenseId: String,
-    private val userId: String
+    private val userAgent: String,
+    private val userId: String,
 ) {
 
     sealed class Content(val page: Int) {
@@ -41,17 +42,21 @@ internal class MediaShareService(
         }
 
         val requestDTO = MediaShareRequestDTO(
-            contentType, feature, userId
+            content = contentType,
+            feature = feature,
+            userId = userId,
+            userAgent = userAgent,
         )
 
         return service.getContent(getHeadersMap(), requestDTO)
     }
 
-    fun getTags(userId: String):Single<PopularTagsResponse> {
+    fun getTags(userId: String): Single<PopularTagsResponse> {
         val requestDTO = MediaShareRequestDTO(
-            contentType,
-            MediaShareRequestDTO.Feature.Tags,
-            userId
+            content = contentType,
+            feature = MediaShareRequestDTO.Feature.Tags,
+            userId = userId,
+            userAgent = userAgent,
         )
 
         return service.getPopularTags(getHeadersMap(), requestDTO)

--- a/mediashare/src/main/java/co/thingthing/fleksyapps/mediashare/network/models/MediaShareRequestDTO.kt
+++ b/mediashare/src/main/java/co/thingthing/fleksyapps/mediashare/network/models/MediaShareRequestDTO.kt
@@ -6,7 +6,8 @@ internal data class MediaShareRequestDTO(
     val userId: String,
     val platform: String = "android",
     val adWidth: Int = 100,
-    val adHeight: Int = 100
+    val adHeight: Int = 100,
+    val userAgent: String = ""
 ) {
 
     enum class ContentType(val requiredCapability: String) {

--- a/mediashare/src/main/java/co/thingthing/fleksyapps/mediashare/network/models/MediaShareRequestDTOAdapter.kt
+++ b/mediashare/src/main/java/co/thingthing/fleksyapps/mediashare/network/models/MediaShareRequestDTOAdapter.kt
@@ -19,6 +19,7 @@ internal class MediaShareRequestDTOAdapter : JsonSerializer<MediaShareRequestDTO
             addProperty("platform", src.platform)
             addProperty("adWidth", src.adWidth)
             addProperty("adHeight", src.adHeight)
+            addProperty("userAgent", src.userAgent)
 
             when (src.feature) {
                 is MediaShareRequestDTO.Feature.Tags -> addProperty("feature", "tags")


### PR DESCRIPTION
* Added extension method for receiving UserAgent field from WebView
* Added userAgent field request for all exiting request
* Added userAgent serialization logic