### PR TITLE
fix: [FSDK-2243] The clips are not muted when they move out of screen

### DIFF
--- a/base/src/main/java/co/thingthing/fleksyapps/base/BaseKeyboardApp.kt
+++ b/base/src/main/java/co/thingthing/fleksyapps/base/BaseKeyboardApp.kt
@@ -140,6 +140,10 @@ abstract class BaseKeyboardApp : KeyboardApp {
      * Width of the carousel views in pixels
      */
     var carouselWidthPx = 0
+
+    /**
+     * Set of visible items positions at current moment
+     */
     private var visibleItems = mutableSetOf<Int>()
 
     /**

--- a/base/src/main/java/co/thingthing/fleksyapps/base/BaseResultAdapter.kt
+++ b/base/src/main/java/co/thingthing/fleksyapps/base/BaseResultAdapter.kt
@@ -45,8 +45,8 @@ class BaseResultAdapter : BaseAdapter<BaseResult>() {
     private fun muteAllVideosExceptItem(item: BaseResult.VideoWithSound) {
         items
             .filterIsInstance<BaseResult.VideoWithSound>()
-            .find { it.id != item.id}
-            ?.apply { muteItemIfNotMuted(item) }
+            .filter { it.id != item.id }
+            .forEach { muteItemIfNotMuted(it) }
     }
 
     /**

--- a/base/src/main/java/co/thingthing/fleksyapps/base/BaseResultAdapter.kt
+++ b/base/src/main/java/co/thingthing/fleksyapps/base/BaseResultAdapter.kt
@@ -45,14 +45,37 @@ class BaseResultAdapter : BaseAdapter<BaseResult>() {
     private fun muteAllVideosExceptItem(item: BaseResult.VideoWithSound) {
         items
             .filterIsInstance<BaseResult.VideoWithSound>()
-            .find { it.id != item.id && it.isNotMuted() }
-            ?.apply {
+            .find { it.id != item.id}
+            ?.apply { muteItemIfNotMuted(item) }
+    }
+
+    /**
+     * Mutes specific item if it is not muted before
+     *
+     * @param item that should be muted
+     */
+    private fun muteItemIfNotMuted(item: BaseResult.VideoWithSound) {
+        item.apply {
+            if (isNotMuted()) {
                 mute()
                 val index = items.indexOf(this)
                 if (index != NOT_FOUND_INDEX) {
                     notifyItemChanged(index)
                 }
             }
+        }
+    }
+
+    /**
+     * Notifies that the item is no longer visible on the screen
+     *
+     * @param position of the item that is no longer visible
+     */
+    fun onItemOutOfScreen(position: Int) {
+        when (val item = items[position]) {
+            is BaseResult.VideoWithSound -> muteItemIfNotMuted(item)
+            else -> {} // do nothing
+        }
     }
 
     override fun getItemViewType(position: Int) =

--- a/base/src/main/java/co/thingthing/fleksyapps/base/utils/Extensions.kt
+++ b/base/src/main/java/co/thingthing/fleksyapps/base/utils/Extensions.kt
@@ -3,6 +3,10 @@ package co.thingthing.fleksyapps.base.utils
 import android.content.Context
 import android.content.res.Resources
 import android.view.View
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.LayoutManager
+import androidx.recyclerview.widget.StaggeredGridLayoutManager
 import co.thingthing.fleksyapps.base.BaseMedia
 import java.util.UUID
 
@@ -29,6 +33,42 @@ fun Context.getInstallationUniqueId(): String {
     return uniqueID
 }
 // endregion
+
+/**
+ * Method finds a range of visible item's positions and casts it to Set<Int>
+ *
+ * @return the Set<Int> of positions of the elements that are visible on the screen
+ */
+fun LayoutManager.getVisibleItemPositions(): Set<Int> {
+    var firstVisibleItemPosition = 0
+    var lastVisibleItemPosition = 0
+    when (this) {
+        is LinearLayoutManager -> {
+            firstVisibleItemPosition = findFirstVisibleItemPosition()
+            lastVisibleItemPosition = findLastVisibleItemPosition()
+        }
+        is StaggeredGridLayoutManager -> {
+            firstVisibleItemPosition = findFirstVisibleItemPositions(null).minOrNull() ?: 0
+            lastVisibleItemPosition = findLastVisibleItemPositions(null).maxOrNull() ?: 0
+        }
+    }
+    return (firstVisibleItemPosition..lastVisibleItemPosition).toSet()
+}
+
+/**
+ * Attaches a scroll listener to the RecyclerView that triggers a specified action
+ * whenever the RecyclerView is scrolled.
+ *
+ * @param action The action to perform on each scroll event.
+ */
+fun RecyclerView.onScrolledListener(action: () -> Unit) {
+    addOnScrollListener(object : RecyclerView.OnScrollListener() {
+        override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+            super.onScrolled(recyclerView, dx, dy)
+            action()
+        }
+    })
+}
 
 fun View.hide() {
     visibility = View.GONE

--- a/base/src/main/java/co/thingthing/fleksyapps/base/viewholders/VideoWithSoundViewHolder.kt
+++ b/base/src/main/java/co/thingthing/fleksyapps/base/viewholders/VideoWithSoundViewHolder.kt
@@ -24,7 +24,7 @@ class VideoWithSoundViewHolder(
     override fun bind(viewModel: BaseResult) {
         super.bind(viewModel)
         (viewModel as BaseResult.VideoWithSound).let { vm ->
-            createExoPlayer()
+            createExoPlayerIfNeeded()
             renderVideo(item = vm)
             renderAudioButton(item = vm)
             renderLabel(label = vm.label)
@@ -32,7 +32,9 @@ class VideoWithSoundViewHolder(
         }
     }
 
-    private fun createExoPlayer() { exoPlayer = ExoPlayer.Builder(binding.root.context).build() }
+    private fun createExoPlayerIfNeeded() {
+        if (exoPlayer == null) exoPlayer = ExoPlayer.Builder(binding.root.context).build()
+    }
 
     private fun getAudioIcon(isMuted: Boolean) = if (isMuted) R.drawable.ic_mute else R.drawable.ic_unmute
 


### PR DESCRIPTION
* Fixed "clips are not muted" issue
* Did exoplayer optimization for smooth viewing and resources recycling
* Previously when we push mute button, only the first unmuted video was muted, but actually we expect that all unmuted video will be muted
* Added some comments