### PR TITLE
fix: [FSDK-2328] Ask ad permission in runtime or remove Idfa

### DIFF
--- a/mediashare/src/main/AndroidManifest.xml
+++ b/mediashare/src/main/AndroidManifest.xml
@@ -1,3 +1,7 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission
+        android:name="com.google.android.gms.permission.AD_ID"
+        tools:node="remove" />
 </manifest>

--- a/mediashare/src/main/java/co/thingthing/fleksyapps/mediashare/network/Extensions.kt
+++ b/mediashare/src/main/java/co/thingthing/fleksyapps/mediashare/network/Extensions.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.webkit.WebView
 import co.thingthing.fleksyapps.mediashare.MediaShareApp
 import co.thingthing.fleksyapps.mediashare.network.models.MediaShareRequestDTO
+import co.thingthing.fleksyapps.mediashare.utils.DeviceInfoProvider.Companion.INVALID_IDFA
 import com.google.android.gms.ads.identifier.AdvertisingIdClient
 
 
@@ -16,7 +17,8 @@ internal fun MediaShareApp.ContentType.toNetworkContentType() = when (this) {
 internal fun Context?.getUserAgent() = this?.let { WebView(it).settings.userAgentString }.orEmpty()
 
 internal fun Context?.getDeviceIfa() = try {
-    this?.let { AdvertisingIdClient.getAdvertisingIdInfo(it).id }
+    val idfa = this?.let { AdvertisingIdClient.getAdvertisingIdInfo(it).id }
+    idfa.takeIf { it != INVALID_IDFA }
 } catch (e: Exception) {
     null
 }

--- a/mediashare/src/main/java/co/thingthing/fleksyapps/mediashare/utils/DeviceInfoProvider.kt
+++ b/mediashare/src/main/java/co/thingthing/fleksyapps/mediashare/utils/DeviceInfoProvider.kt
@@ -8,6 +8,13 @@ import co.thingthing.fleksyapps.mediashare.network.getDeviceIfa
  * Provides device-related information for the current Android device.
  */
 interface DeviceInfoProvider {
+    companion object {
+        /**
+         * Represents an invalid or unavailable IDFA.
+         */
+        const val INVALID_IDFA = "00000000-0000-0000-0000-000000000000"
+    }
+
     /** The version of the operating system running on the device. */
     val operatingSystemVersion: String
 


### PR DESCRIPTION
* Explicitly removed the com.google.android.gms.permission.AD_ID permission
* Added logic to check if the IDFA consists of zeros and remove it from the request in such cases