### PR TITLE
fix: [FSDK-2407] App crashes with new Mediashare version

### DIFF
--- a/base/src/main/java/co/thingthing/fleksyapps/base/BaseResult.kt
+++ b/base/src/main/java/co/thingthing/fleksyapps/base/BaseResult.kt
@@ -14,7 +14,7 @@ sealed class BaseResult(
     }
 
     open class Image(
-        override val id: String,
+        override val id: String? = null,
         val image: List<BaseMedia>,
         val thumbnail: List<BaseMedia>? = null,
         val placeholder: List<BaseMedia>? = null,


### PR DESCRIPTION
* base module is used by other modules but an id is not required for all modules