### PR TITLE
fix: [FSDK-2452] Fix vulnerable okio version

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -48,7 +48,11 @@ dependencies {
     api "com.google.code.gson:gson:2.11.0"
     api 'io.reactivex.rxjava2:rxjava:2.2.21'
     api 'io.reactivex.rxjava2:rxandroid:2.1.1'
-    api "com.squareup.okhttp3:okhttp:4.11.0"
+    api "com.squareup.okhttp3:okhttp:4.12.0"
+
+    implementation("com.squareup.okio:okio:3.4.0") {
+        because("Fixes CVE-2023-3635 in earlier versions")
+    }
 
     api "com.facebook.fresco:fresco:3.2.0"
     api 'com.facebook.fresco:animated-gif:3.2.0'

--- a/mediashare/build.gradle
+++ b/mediashare/build.gradle
@@ -48,4 +48,8 @@ dependencies {
 
     //implementation("co.thingthing.fleksyapps:base:2.2.0")
     api project(':base')
+
+    implementation("com.squareup.okio:okio:3.4.0") {
+        because("Fixes CVE-2023-3635 in earlier versions")
+    }
 }


### PR DESCRIPTION
* Updated okhttp to version that have safe okio version
* Added implicit implementation of okio safe version and added commentary why do we need this